### PR TITLE
Minor style fixes & new article

### DIFF
--- a/_includes/article.html
+++ b/_includes/article.html
@@ -1,5 +1,5 @@
 <article itemtype="http://schema.org/BlogPosting" itemscope="" class="bounceInRight animation-speed-normal animation-fill-backwards font-article">
-	<header class="article-meta sticky shadow-dark z-2">
+	<header class="article-meta sticky-desktop shadow-dark z-2">
 		<h2 class="font-title" itemprop="headline">{{ page.title }}</h2>
 		{% if site.data.authors[page.author] != null %}
 			{% include by-line.html %}

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,10 +1,11 @@
 <nav class="sticky top shadow-dark color-alt flex row title-font center no-text-decoration z-3" role="navigation" itemtype="http://schema.org/SiteNavigationElement" itemscope="">
-	<a href="{{'/#top' | absolute_url }}">
+	<a href="{% if page.layout == 'home' %}{{'/#top' | absolute_url }}{% else %}{{'/' | absolute_url}}{% endif %}">
 		<svg class="current-color icon">
 			<use xlink:href="{{ '/img/icons.svg#favicon' | absolute_url }}" />
 		</svg>
 	</a>
 	<span data-show-modal="#about-dialog" class="cursor-pointer">About</span>
 	{% if page.layout == 'home' %}<a href="#portfolio">Portfolio</a>{% endif %}
-	<a href="#contact">Contact</a>
+	<a href="#pinned-posts">Pinned Posts</a>
+	<a href="#recent-posts">Recent Posts</a>
 </nav>

--- a/_posts/2017-10-19-the-secret-to-seo.md
+++ b/_posts/2017-10-19-the-secret-to-seo.md
@@ -1,0 +1,181 @@
+---
+layout: post
+title: "The Secret to SEO"
+date: "2017-10-19 04:30:48 -0700"
+author: Chris Zuber
+author_url: https://chriszuber.com
+image: https://i.imgur.com/cFKqWym.png
+pinned: true
+description: "You've seen the emails of supposed SEO experts, but the secret to SEO is that there is no secret"
+keywords:
+- seo
+- microdata
+- schema.org
+- json+ld
+- json linked documents
+---
+![SEO meme](https://i.imgur.com/cFKqWym.png)
+
+If you work on websites to any significant degree, <abbr title="Search Engine Optimizations">SEO</abbr>
+is a term you're probably familiar with. Some associate it with spam. Others,
+think of it as some magical set of constantly changing rules to follow to get on
+the front page of Google. Others, and probably too few, really understand what it
+is all about.
+
+If you thik about it from the persepective of a search engine for a moment, it all
+becomes clear very quickly. What is the primary goal of a search engine
+(*aside from displaying ads*)? To get users to the content they are looking for.
+
+With this in mind, good SEO breaks down into two very simple rules:
+1. Have good content.
+2. Help search engines understand the content
+
+### The content
+Creating high quality content is not terribly difficult, depending on the subject
+matter. It requires a little bit of empathy and working with your audience in mind.
+If you write an article with the intention of bringing eyes to your site, you might
+be doing it wrong. Writing to be informative or educational to your audience is
+much more effective than writing to bait an audience.
+
+If possible, be a little informal and have some personality. Even if what you are
+writing is educational, you can still be creative and entertain your audience in
+the process.
+
+Be empathetic. Be creative. Know your audience. Make something they will want
+to consume.
+
+### The markup
+![Rich markup created event](https://i.imgur.com/hsVUFHO.png)
+
+As effective as search engines are at crawling and parsing your sites, they're
+still not as good at understanding them as us mortals. Because they were smart
+enough to know that content creators want their stuff showing up in search results,
+Google, Microsoft, Yahoo, Yandex, and others founded [schema.org](https://schema.org).
+
+schema.org is a site that hosts documentation for something that goes by many names.
+Whether you want to call it microdata or structured data, schema.org defines the
+vocabulary that allows for semantic markup that search engines can not only parse,
+but also **understand**.
+
+The basic markup requires three attributes:
+- [`itemtype`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/itemtype),
+which is also a link to the vocabulary's definition
+- [`itemprop`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/itemprop),
+which relates the content to the `itemtype`
+- [`itemscope`](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/itemscope),
+which is effectively a container for atttributes of an `itemtype`
+
+It may be delivered in a few different ways:
+
+**HTML in page** [PostalAddress](https://schema.org/PostalAddress)
+```html
+<address itemprop="homeAddress" itemtype="http://schema.org/PostalAddress" itemscope>
+    <div itemprop="streetAddress">123 Some St.</div>
+    <div>
+        <span itemprop="addressLocality">My City</span>,
+        <span itemprop="addressRegion">CA</span>
+    </div>
+    <ul>
+        <!--
+            Note the `content` attribute used since they would be read with the
+            "mailto:" or "tel:" prefixes
+        -->
+        <li><a itemprop="email" href="mailto:user@example.com" content="user@example.com">user@example.com</li>
+        <li><a itemprop="telephone" href="tel:+1-555-123-4567" content="+1-555-123-4567">(555) 123-4567</li>
+    </ul>
+    <!-- ... -->
+</figure>
+```
+
+**<abbr title="JSON Linked Document">JSON-LD</abbr>** [ImageObject](https://schema.org/ImageObject)
+
+*(can validate by URL but probably will not be used if linked in HTML)*
+```json
+{
+    "@type": "ImageObject",
+    "@context": "http://schema.org",
+    "url": "...",
+    "caption": "...",
+    "creator": "..."
+}
+```
+
+**Embedding JSON-LD into HTML by `<script>`** [Person](https://schema.org/Person)
+```html
+<script type="application/ld+json">
+    {
+        "@type": "Person",
+        "@context": "http://schema.org",
+        "givenName": "...",
+        "additionalName": "...",
+        "familyName": "...",
+        "homeAddress": {
+            "@type": "PostalAddress",
+            ...
+        },
+        "image": {
+            "@type": "ImageObject",
+            ...
+        }
+    }
+</script>
+```
+
+To see this in action, check out the
+[structured data for this page](https://search.google.com/structured-data/testing-tool#url=https%3A%2F%2Fshgysk8zer0.github.io%2F2017%2F10%2F19%2Fthe-secret-to-seo.html)
+
+In my opinion, `<script type="application/ld+json">` is the easiest to implement
+because it allows you to dump all the data into a page without worrying how to
+do the markup for exif data for an image, but adding `itemtype` and `itemprop`
+to your HTML is the most powerful, as it gives you better semantics for styling
+and scripting.
+
+Imagine the following:
+
+```javascript
+document.addEventListener('load', async () => {
+    // Fetch data from JSON document
+    const resp = await fetch(new URL('/Article/3bc34a45d26784b5bea8529db533ae84', location.origin));
+    const data = await resp.json();
+    // Load a template
+    const template = document.getElementById('article-template').content.cloneNode(true);
+
+    // Iterate though template, populating with fetched data
+    [..template.querySelectorAll('[itemprop]')].forEach(el => {
+        if (data.hasOwnProperty(el.getAttribute('itemprop'))) {
+            el.textContent = data[el.getAttribute('itemprop')];
+        } else {
+            el.remove();
+        }
+    });
+
+    // Append to DOM
+    document.querySelector('.article-container').append(template);
+}, {once: true);
+```
+
+```css
+[itemtype="http://schem.org/Article"] [itemprop="author"] {
+    /* Styles for authors of articles */
+}
+```
+
+### Design
+Performance, legibility, and affordance are all important aspects SEO, though
+indirectly. Google does take accessibility and mobile readiness into account,
+but the bigger impact will likely be from your audience's impact.
+
+Good desing is more of an art than any of the other topics and, to be honest, is
+something that I admit I am not quite an expert on. What I can say though is that
+empathy is important.
+
+### Other free tips:
+- HTTPS is more important than ever
+- Keywords don't really matter because they're too easy to "stuff" / spam
+- `<meta name="description">` will most likely show up in search results, so use it
+- People like images, and search engines are in the business of showing people
+what they like
+- Know the differene between "Likes" on Facebook and site engagement
+- Use appropriate elements such as `<article>`, `<time>`, `<address>` as well
+- The more semantic your markup, the better
+

--- a/css/styles/layout.css
+++ b/css/styles/layout.css
@@ -4,7 +4,7 @@
 
 @media (min-width: 601px) {
 	body {
-		grid-template-columns: 1fr 14fr 5fr;
+		grid-template-columns: 2vw 75vw 23vw;
 		grid-template-areas: 'header header header'
 		'nav nav nav'
 		'. main pinned-posts'
@@ -16,7 +16,11 @@
 
 @media (max-width: 600px) {
 	body {
-		grid-template-areas: 'header' 'nav' 'pinned-posts' 'main' 'recent-posts' 'footer';
 		grid-auto-columns: 100%;
+		grid-template-areas: 'header' 'nav' 'main' 'pinned-posts' 'recent-posts' 'footer';
+	}
+
+	.layout-home {
+		grid-template-areas: 'header' 'nav' 'pinned-posts' 'main' 'recent-posts' 'footer';
 	}
 }

--- a/css/styles/nav.css
+++ b/css/styles/nav.css
@@ -11,11 +11,16 @@ body > nav {
 body > nav > * {
 	flex: 1 0 auto;
 	line-height: var(--nav-height);
+	height: var(--nav-height);
 	background-image: inherit;
 }
 
 body > nav > *:first-child {
 	border-radius: 0 0 0 1rem;
+	flex-basis: 6rem;
+	flex-grow: 0;
+	align-self: flex-start;
+	justify-self: flex-start;
 }
 
 body > nav > *:last-child {
@@ -29,3 +34,4 @@ body > nav > *:not(:last-child) {
 body > nav > *:hover {
 	background-image: linear-gradient(#222, #444);
 }
+

--- a/manifest.json
+++ b/manifest.json
@@ -1,5 +1,5 @@
 {
-	"version": "3.2.2",
+	"version": "3.2.3",
 	"name": "Chris Zuber | Portfolio",
 	"short_name": "Chris Zuber",
 	"description": "Info and work examples from Chris Zuber",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "about",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "A responsive, progressive about / portfolio & blog page built using Jekyll",
   "main": "index.html",
   "scripts": {
@@ -17,11 +17,11 @@
     "build:icons": "svg-sprite-generate -c img/icons.csv -o img/icons.svg",
     "build:all": "npm run build:icons && npm run build:css && npm run build:js",
     "build:site": "npm run build:all && JEKYLL_ENV=production jekyll build",
-    "build:site:dev": "bundle exec jekyll build --incremental",
+    "build:site:dev": "bundle exec jekyll build --incremental --drafts",
     "postinstall": "npm run git:fetch && npm run git:submodules && npm run build:all",
 	"serve": "npm run serve:production --incremental",
 	"serve:production": "npm run build:all && JEKYLL_ENV=production bundle exec jekyll serve --incremental",
-	"serve:dev": "bundle exec jekyll serve"
+	"serve:dev": "bundle exec jekyll serve --drafts"
   },
   "repository": {
     "type": "git",

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,5 @@
 const config = {
-	version: '3.2.2',
+	version: '3.2.3',
 	caches: [
 		'/',
 		'/js/index.min.js',


### PR DESCRIPTION
## Fix style hiccups and add SEO article

## Pull-Request check-list
- [x] Ran `npm run build:all` to update generated content
- [x] Updated scripts & stylesheets to use minified/transpiled resources
- [x] Updated ServiceWorker caches, if needed
- [x] Updated version in `manifest.json`, `package.json`, & `service-worker.js`

### List of significant changes made
- Make article header only sticky on desktop
- Home/top icon varies setting anchor based on layout
- Add links for recent & pinned posts
- Set columns using `vw` for more precise/consistent sizing
- Move pinned posts below `<main>` except on home page
- Reduce home/top link width to allow for new links
- Add article on SEO